### PR TITLE
docstring-to-markdown 0.11

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,6 +17,8 @@ requirements:
   host:
     - pip
     - python
+    - wheel
+    - setuptools
   run:
     - python
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -39,6 +39,7 @@ about:
     In the future will be able to convert Google docstrings too
   license: LGPL-2.1-or-later
   license_file: LICENSE
+  license_family: LGPL
   dev_url: https://github.com/python-lsp/docstring-to-markdown
   doc_url: https://github.com/python-lsp/docstring-to-markdown/blob/main/README.md
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,15 +10,15 @@ source:
 
 build:
   number: 0
-  noarch: python
-  script: {{ PYTHON }} -m pip install . -vv
+  script: {{ PYTHON }} -m pip install . -vv --no-deps
+  skip: True  # [py<36]
 
 requirements:
   host:
     - pip
-    - python >=3.6
+    - python
   run:
-    - python >=3.6
+    - python
 
 test:
   imports:
@@ -31,9 +31,14 @@ test:
 about:
   home: https://pypi.org/project/docstring-to-markdown
   summary: On the fly conversion of Python docstrings to markdown
+  description: |
+    On the fly conversion of Python docstrings to markdown.
+    Currently can recognise reStructuredText and convert multiple of its features to Markdown.
+    In the future will be able to convert Google docstrings too
   license: LGPL-2.1-or-later
   license_file: LICENSE
   dev_url: https://github.com/python-lsp/docstring-to-markdown
+  doc_url: https://github.com/python-lsp/docstring-to-markdown/blob/main/README.md
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
# docstring-to-markdown 0.11

upstream: https://github.com/python-lsp/docstring-to-markdown/tree/v0.11
jira: https://anaconda.atlassian.net/browse/PKG-981
license: https://github.com/python-lsp/docstring-to-markdown/blob/v0.11/LICENSE
`setup.py`: https://github.com/python-lsp/docstring-to-markdown/blob/v0.11/setup.py

## Changes
- Remove noarch
- Update about section

## Notes
- This package is not currently on defaults